### PR TITLE
Fix typo on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1558,7 +1558,7 @@
               <i class="icon ni ni-camera-compact"></i>
               <i class="icon ni ni-chart-bar-32"></i>
             </div>
-            <span class="blur-hidden h5 text-success">Eplore all the 21.000+ Nucleo Icons</span>
+            <span class="blur-hidden h5 text-success">Explore all the 21.000+ Nucleo Icons</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
Explore was written as "Eplore" on the blur over nucleo icons.