### PR TITLE
Upgrade 8 outdated packages to fix 26 vulnerabilities.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,27 +9,27 @@
   },
   "devDependencies": {
     "browser-sync": "^2.24.4",
-    "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^5.0.0",
-    "gulp-clean-css": "^3.9.4",
-    "gulp-imagemin": "^4.1.0",
-    "gulp-sass": "^3.2.1",
+    "gulp": "^4.0.2",
+    "gulp-autoprefixer": "^7.0.1",
+    "gulp-clean-css": "^4.2.0",
+    "gulp-imagemin": "^6.1.1",
+    "gulp-sass": "^4.0.2",
     "gulp-util": "^3.0.8"
   },
   "dependencies": {
-    "del": "^3.0.0",
+    "del": "^5.1.0",
     "gulp-cache": "^1.0.2",
     "gulp-csscomb": "^3.0.8",
     "gulp-cssnano": "^2.1.3",
     "gulp-html-prettify": "0.0.1",
     "gulp-npm-dist": "^1.0.1",
-    "gulp-postcss": "^7.0.1",
+    "gulp-postcss": "^8.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-run": "^1.7.1",
     "gulp-uglify": "^3.0.0",
     "gulp-useref-plus": "0.0.8",
     "gulp-wait": "0.0.2",
-    "postcss-flexbugs-fixes": "^3.3.1",
+    "postcss-flexbugs-fixes": "^4.1.0",
     "pump": "^3.0.0",
     "run-sequence": "^2.2.1"
   },
@@ -41,6 +41,5 @@
     "type": "git",
     "url": "git+https://github.com/creativetimofficial/argon-design-system.git"
   },
-  "license": "MIT",
   "homepage": "https://github.com/creativetimofficial/argon-design-system/blob/master/LICENSE.md"
 }

--- a/package.json
+++ b/package.json
@@ -2,19 +2,22 @@
   "name": "argon-design-system",
   "version": "1.1.0",
   "description": "A beautiful Design System for Bootstrap 4. It's Free and Open Source.",
-  "main": "gulpfile.js",
+  "keywords": [
+    "design",
+    "bootstrap",
+    "dashboard",
+    "infoviz"
+  ],
+  "homepage": "https://github.com/creativetimofficial/argon-design-system",
+  "bugs": {
+    "url": "https://github.com/creativetimofficial/argon-design-system/issues"
+  },
+  "license": "MIT",
   "author": "Creative Tim",
+  "main": "gulpfile.js",
+  "repository": "github.com:creativetimofficial/argon-design-system",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "devDependencies": {
-    "browser-sync": "^2.24.4",
-    "gulp": "^4.0.2",
-    "gulp-autoprefixer": "^7.0.1",
-    "gulp-clean-css": "^4.2.0",
-    "gulp-imagemin": "^6.1.1",
-    "gulp-sass": "^4.0.2",
-    "gulp-util": "^3.0.8"
   },
   "dependencies": {
     "del": "^5.1.0",
@@ -33,13 +36,13 @@
     "pump": "^3.0.0",
     "run-sequence": "^2.2.1"
   },
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/creativetimofficial/argon-design-system/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/creativetimofficial/argon-design-system.git"
-  },
-  "homepage": "https://github.com/creativetimofficial/argon-design-system/blob/master/LICENSE.md"
+  "devDependencies": {
+    "browser-sync": "^2.24.4",
+    "gulp": "^4.0.2",
+    "gulp-autoprefixer": "^7.0.1",
+    "gulp-clean-css": "^4.2.0",
+    "gulp-imagemin": "^6.1.1",
+    "gulp-sass": "^4.0.2",
+    "gulp-util": "^3.0.8"
+  }
 }


### PR DESCRIPTION
When running a `yarn install` (or any other method for that matter) there are a total of eight outdated packages which carry with them 26 vulnerabilities. This PR upgrades these packages and solves these core issues.

## Installing

```console
$ yarn install
yarn install v1.19.1
warning ../package.json: No license field
info No lockfile found.
[1/4] 🔍  Resolving packages...
warning gulp-csscomb > csscomb > csscomb-core > minimatch@0.2.12: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning gulp-csscomb > csscomb > csscomb-core > vow-fs > glob > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning gulp-csscomb > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning gulp-csscomb > csscomb > csscomb-core > vow-fs > node-uuid@1.4.0: Use uuid module instead
warning gulp-cssnano > cssnano > autoprefixer > browserslist@1.7.7: Browserslist 2 could fail on reading Browserslist >3.0 config used in other tools.
warning gulp-cssnano > cssnano > postcss-merge-rules > browserslist@1.7.7: Browserslist 2 could fail on reading Browserslist >3.0 config used in other tools.
warning gulp-cssnano > cssnano > postcss-merge-rules > caniuse-api > browserslist@1.7.7: Browserslist 2 could fail on reading Browserslist >3.0 config used in other tools.
warning gulp-html-prettify > gulp-util@0.0.1: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning gulp-run > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning gulp-useref-plus > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning browser-sync > chokidar > fsevents@1.2.9: One of your dependencies needs to upgrade to fsevents v2: 1) Proper nodejs v10+ support 2) No more fetching binaries from AWS, smaller package size
warning gulp > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning gulp > vinyl-fs > glob-stream > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning gulp > vinyl-fs > glob-stream > glob > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning gulp > vinyl-fs > graceful-fs > natives@1.1.6: This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.
warning gulp > vinyl-fs > glob-watcher > gaze > globule > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning gulp > vinyl-fs > glob-watcher > gaze > globule > glob > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning gulp > vinyl-fs > glob-watcher > gaze > globule > glob > graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
warning gulp-imagemin > imagemin-gifsicle > gifsicle > bin-build > download > gulp-decompress > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning gulp-sass > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
warning gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
✨  Done in 90.03s.
```

## Outdated Packages

As at `2019-10-11` the following command shows a list of outdated packages.

```console
$ yarn outdated
yarn outdated v1.19.1
info Color legend :
 "<red>"    : Major Update backward-incompatible updates
 "<yellow>" : Minor Update backward-compatible features
 "<green>"  : Patch Update backward-compatible bug fixes
Package                Current Wanted Latest Package Type    URL
del                    3.0.0   3.0.0  5.1.0  dependencies    https://github.com/sindresorhus/del#readme
gulp                   3.9.1   3.9.1  4.0.2  devDependencies https://gulpjs.com
gulp-autoprefixer      5.0.0   5.0.0  7.0.1  devDependencies https://github.com/sindresorhus/gulp-autoprefixer#readme
gulp-clean-css         3.10.0  3.10.0 4.2.0  devDependencies https://github.com/scniro/gulp-clean-css#readme
gulp-imagemin          4.1.0   4.1.0  6.1.1  devDependencies https://github.com/sindresorhus/gulp-imagemin#readme
gulp-postcss           7.0.1   7.0.1  8.0.0  dependencies    https://github.com/postcss/gulp-postcss
gulp-sass              3.2.1   3.2.1  4.0.2  devDependencies https://github.com/dlmanning/gulp-sass#readme
postcss-flexbugs-fixes 3.3.1   3.3.1  4.1.0  dependencies    https://github.com/luisrudge/postcss-flexbugs-fixes#readme
✨  Done in 0.68s.
```

## Performing an Upgrade

Upgrading `package.json` was done via the following command:

```console
$ yarn upgrade -L -C del gulp gulp-autoprefixer gulp-clean-css gulp-imagemin gulp-postcss gulp-sass postcss-flexbugs-fixes
yarn upgrade v1.19.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Rebuilding all packages...
success Saved lockfile.
success Saved 162 new dependencies.
info Direct dependencies
├─ del@5.1.0
├─ gulp-autoprefixer@7.0.1
├─ gulp-clean-css@4.2.0
├─ gulp-imagemin@6.1.1
├─ gulp-postcss@8.0.0
├─ gulp-sass@4.0.2
├─ gulp@4.0.2
└─ postcss-flexbugs-fixes@4.1.0
info All dependencies
├─ @nodelib/fs.scandir@2.1.3
├─ @nodelib/fs.stat@2.0.3
[...]
└─ yauzl@2.10.0
✨  Done in 35.38s.
```
**NB:** Additional output from `All dependencies` were redacted for brevity.
